### PR TITLE
Fix: Apply custom styling to CalcomButton for popular plan

### DIFF
--- a/app/components/CalcomButton.tsx
+++ b/app/components/CalcomButton.tsx
@@ -1,15 +1,21 @@
 'use client';
 import { CalcomEmbed } from "@calcom/embed-react";
 
-export default function CalcomButton({ buttonText }: { buttonText: string }) {
-  const buttonClass = "inline-flex items-center justify-center rounded-md bg-indigo-600 px-4 py-2 text-sm font-semibold text-white shadow-sm hover:bg-indigo-500";
+export default function CalcomButton({
+  buttonText,
+  buttonClass
+}: {
+  buttonText: string,
+  buttonClass?: string
+}) {
+  const defaultClass = "inline-flex items-center justify-center rounded-md bg-indigo-600 px-4 py-2 text-sm font-semibold text-white shadow-sm hover:bg-indigo-500";
 
   return (
     <CalcomEmbed
       calLink="mcollis/30min"
       config={{ layout: "month_view" }}
     >
-      <button className={buttonClass}>
+      <button className={buttonClass || defaultClass}>
         {buttonText}
       </button>
     </CalcomEmbed>

--- a/app/components/services-preview.tsx
+++ b/app/components/services-preview.tsx
@@ -86,13 +86,12 @@ export default function ServicesPreview() {
 
               <div className="mt-8">
                 {service.popular ? (
-                  <div className="w-full bg-white text-blue-600 px-4 py-2 rounded-lg font-medium hover:bg-blue-50 transition-colors inline-block text-center">
-                    <CalcomButton buttonText="Get Started" />
-                  </div>
+                  <CalcomButton
+                    buttonText="Get Started"
+                    buttonClass="inline-flex items-center justify-center rounded-md bg-white px-4 py-2 text-sm font-semibold text-indigo-600 shadow-sm ring-1 ring-inset ring-indigo-600 hover:bg-indigo-50"
+                  />
                 ) : (
-                  <div className="w-full bg-blue-600 text-white px-4 py-2 rounded-lg font-medium hover:bg-blue-700 transition-colors inline-block text-center">
-                    <CalcomButton buttonText="Get Started" />
-                  </div>
+                  <CalcomButton buttonText="Get Started" />
                 )}
               </div>
             </div>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * Calcom button now supports custom styling, allowing tailored appearance where needed.
* Refactor
  * Simplified popular services rendering by removing an extra wrapper and rendering the button directly.
* Style
  * Popular services now apply styles directly to the button for a cleaner, more consistent look.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->