### PR TITLE
Fix TypeScript path aliases and add Next.js configuration

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,0 +1,7 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  reactStrictMode: true,
+  swcMinify: true,
+}
+
+export default nextConfig

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,11 @@
 {
   "compilerOptions": {
     "target": "ES2017",
-    "lib": ["dom", "dom.iterable", "esnext"],
+    "lib": [
+      "dom",
+      "dom.iterable",
+      "esnext"
+    ],
     "allowJs": true,
     "skipLibCheck": true,
     "strict": true,
@@ -19,9 +23,18 @@
       }
     ],
     "paths": {
-      "@/*": ["./*"]
+      "@/*": [
+        "./app/*"
+      ]
     }
   },
-  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
-  "exclude": ["node_modules"]
+  "include": [
+    "next-env.d.ts",
+    "**/*.ts",
+    "**/*.tsx",
+    ".next/types/**/*.ts"
+  ],
+  "exclude": [
+    "node_modules"
+  ]
 }


### PR DESCRIPTION
This PR fixes the TypeScript configuration and adds the missing Next.js configuration file to resolve build errors.

## Changes Made:
1. **Updated tsconfig.json**: Changed path alias from `"@/*": ["./*"]` to `"@/*": ["./app/*"]` to correctly resolve imports in the app directory
2. **Created next.config.mjs**: Added proper Next.js 14+ configuration with app directory support

## Why These Changes:
- The incorrect path alias was causing module resolution errors during Vercel builds
- The missing next.config.mjs was preventing proper app directory configuration

These changes should resolve the Vercel deployment failures.